### PR TITLE
feat: add CSRF protection

### DIFF
--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,0 +1,17 @@
+<?php
+function csrf_token(): string {
+  if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+  if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+  }
+  return $_SESSION['csrf_token'];
+}
+
+function csrf_check(): void {
+  if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+  $token = $_POST['csrf_token'] ?? $_GET['csrf_token'] ?? '';
+  if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+    exit('CSRF token inválido');
+  }
+}
+?>

--- a/views/pages/clientes/actualizar.php
+++ b/views/pages/clientes/actualizar.php
@@ -3,6 +3,9 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();

--- a/views/pages/clientes/editar.php
+++ b/views/pages/clientes/editar.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin = is_admin();
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT) ?: 0;
@@ -22,6 +23,7 @@ if ($isAdmin) {
 <div class="card shadow-sm">
   <form class="card-body" method="post" action="index.php?p=clientes-actualizar">
     <input type="hidden" name="id" value="<?= (int)$c['id'] ?>">
+    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
 
     <?php if ($isAdmin): ?>
       <div class="mb-3">

--- a/views/pages/clientes/estado.php
+++ b/views/pages/clientes/estado.php
@@ -3,6 +3,9 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();

--- a/views/pages/clientes/guardar.php
+++ b/views/pages/clientes/guardar.php
@@ -3,6 +3,9 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();

--- a/views/pages/clientes/index.php
+++ b/views/pages/clientes/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -87,11 +88,11 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <a class="btn btn-sm btn-outline-secondary" href="index.php?p=clientes-editar&id=<?= (int)$c['id'] ?>">Editar</a>
                 <?php if ((int)$c['activo'] === 1): ?>
                   <a class="btn btn-sm btn-outline-warning"
-                     href="index.php?p=clientes-estado&id=<?= (int)$c['id'] ?>&a=desactivar"
+                     href="index.php?p=clientes-estado&id=<?= (int)$c['id'] ?>&a=desactivar&csrf_token=<?= csrf_token() ?>"
                      onclick="return confirm('¿Desactivar este cliente?');">Desactivar</a>
                 <?php else: ?>
                   <a class="btn btn-sm btn-outline-success"
-                     href="index.php?p=clientes-estado&id=<?= (int)$c['id'] ?>&a=activar"
+                     href="index.php?p=clientes-estado&id=<?= (int)$c['id'] ?>&a=activar&csrf_token=<?= csrf_token() ?>"
                      onclick="return confirm('¿Activar este cliente?');">Activar</a>
                 <?php endif; ?>
               </td>

--- a/views/pages/clientes/nuevo.php
+++ b/views/pages/clientes/nuevo.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin = is_admin();
 
@@ -12,6 +13,7 @@ if ($isAdmin) {
 ?>
 <div class="card shadow-sm">
   <form class="card-body" method="post" action="index.php?p=clientes-guardar">
+    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
     <?php if ($isAdmin): ?>
       <div class="mb-3">
         <label class="form-label">Propietario</label>

--- a/views/pages/facturas/estado.php
+++ b/views/pages/facturas/estado.php
@@ -3,6 +3,9 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();

--- a/views/pages/facturas/guardar.php
+++ b/views/pages/facturas/guardar.php
@@ -1,6 +1,9 @@
 <?php
 // views/pages/facturas/guardar.php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $uid            = (int)$_SESSION['usuario_id'];
 $fecha          = $_POST['fecha'] ?? date('Y-m-d');

--- a/views/pages/facturas/index.php
+++ b/views/pages/facturas/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -92,9 +93,9 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <div class="btn-group">
                   <a class="btn btn-sm btn-outline-warning dropdown-toggle" data-bs-toggle="dropdown" href="#">Estado</a>
                   <ul class="dropdown-menu dropdown-menu-end">
-                    <li><a class="dropdown-item" href="index.php?p=facturas-estado&id=<?= (int)$f['id'] ?>&e=borrador">Borrador</a></li>
-                    <li><a class="dropdown-item" href="index.php?p=facturas-estado&id=<?= (int)$f['id'] ?>&e=emitida">Emitida</a></li>
-                    <li><a class="dropdown-item" href="index.php?p=facturas-estado&id=<?= (int)$f['id'] ?>&e=pagada">Pagada</a></li>
+                    <li><a class="dropdown-item" href="index.php?p=facturas-estado&id=<?= (int)$f['id'] ?>&e=borrador&csrf_token=<?= csrf_token() ?>">Borrador</a></li>
+                    <li><a class="dropdown-item" href="index.php?p=facturas-estado&id=<?= (int)$f['id'] ?>&e=emitida&csrf_token=<?= csrf_token() ?>">Emitida</a></li>
+                    <li><a class="dropdown-item" href="index.php?p=facturas-estado&id=<?= (int)$f['id'] ?>&e=pagada&csrf_token=<?= csrf_token() ?>">Pagada</a></li>
                   </ul>
                 </div>
               </td>

--- a/views/pages/facturas/nuevo.php
+++ b/views/pages/facturas/nuevo.php
@@ -1,6 +1,7 @@
 <?php
 // views/pages/facturas/nuevo.php
 require_once __DIR__ . '/../../../includes/auth.php'; // sesión + $pdo
+require_once __DIR__ . '/../../../includes/csrf.php';
 
 $uid = (int)$_SESSION['usuario_id'];
 
@@ -51,6 +52,7 @@ $productos = $stProd->fetchAll(PDO::FETCH_ASSOC);
 </div>
 
 <form method="post" action="index.php?p=facturas-guardar" id="formFactura" class="row g-3">
+  <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
   <div class="col-md-3">
     <label class="form-label">Fecha</label>
     <input type="date" name="fecha" id="f_fecha" class="form-control" value="<?= h($fecha) ?>">

--- a/views/pages/gastos/estado.php
+++ b/views/pages/gastos/estado.php
@@ -2,6 +2,9 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $uid = (int)$_SESSION['usuario_id'];
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;

--- a/views/pages/gastos/guardar.php
+++ b/views/pages/gastos/guardar.php
@@ -2,6 +2,9 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $uid = (int)$_SESSION['usuario_id'];
 

--- a/views/pages/gastos/index.php
+++ b/views/pages/gastos/index.php
@@ -1,6 +1,7 @@
 <?php
 // views/pages/gastos/index.php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 
 $uid = (int)$_SESSION['usuario_id'];
 
@@ -177,13 +178,13 @@ function nf($n){ return number_format((float)$n, 2, ',', '.'); }
 
                   <!-- Acciones de estado -->
                   <?php if ($r['estado']!=='pagado'): ?>
-                    <a class="btn btn-outline-success" href="index.php?p=gastos-estado&id=<?= (int)$r['id'] ?>&to=pagado">Pagado</a>
+                    <a class="btn btn-outline-success" href="index.php?p=gastos-estado&id=<?= (int)$r['id'] ?>&to=pagado&csrf_token=<?= csrf_token() ?>">Pagado</a>
                   <?php endif; ?>
                   <?php if ($r['estado']!=='finalizado'): ?>
-                    <a class="btn btn-outline-primary" href="index.php?p=gastos-estado&id=<?= (int)$r['id'] ?>&to=finalizado">Finalizar</a>
+                    <a class="btn btn-outline-primary" href="index.php?p=gastos-estado&id=<?= (int)$r['id'] ?>&to=finalizado&csrf_token=<?= csrf_token() ?>">Finalizar</a>
                   <?php endif; ?>
                   <?php if ($r['estado']!=='borrador'): ?>
-                    <a class="btn btn-outline-secondary" href="index.php?p=gastos-estado&id=<?= (int)$r['id'] ?>&to=borrador">Borrador</a>
+                    <a class="btn btn-outline-secondary" href="index.php?p=gastos-estado&id=<?= (int)$r['id'] ?>&to=borrador&csrf_token=<?= csrf_token() ?>">Borrador</a>
                   <?php endif; ?>
                 </div>
               </td>

--- a/views/pages/gastos/nuevo.php
+++ b/views/pages/gastos/nuevo.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
 
 // Sugerir categorías previas (texto libre)
@@ -16,6 +17,7 @@ $cats = $st->fetchAll(PDO::FETCH_COLUMN);
 <div class="card shadow-sm">
   <div class="card-body">
     <form method="post" action="index.php?p=gastos-guardar" class="row g-3" enctype="multipart/form-data">
+      <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
       <div class="col-md-3">
         <label class="form-label">Fecha</label>
         <input type="date" name="fecha" class="form-control" value="<?= h(date('Y-m-d')) ?>" required>

--- a/views/pages/productos/actualizar.php
+++ b/views/pages/productos/actualizar.php
@@ -3,6 +3,9 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();

--- a/views/pages/productos/editar.php
+++ b/views/pages/productos/editar.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT) ?: 0;
@@ -22,6 +23,7 @@ if ($isAdmin) {
 <div class="card shadow-sm">
   <form class="card-body" method="post" action="index.php?p=productos-actualizar">
     <input type="hidden" name="id" value="<?= (int)$p['id'] ?>">
+    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
 
     <?php if ($isAdmin): ?>
       <div class="mb-3">

--- a/views/pages/productos/estado.php
+++ b/views/pages/productos/estado.php
@@ -3,6 +3,9 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();

--- a/views/pages/productos/guardar.php
+++ b/views/pages/productos/guardar.php
@@ -3,6 +3,9 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
+
+csrf_check();
 
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();

--- a/views/pages/productos/index.php
+++ b/views/pages/productos/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -92,11 +93,11 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <a class="btn btn-sm btn-outline-secondary" href="index.php?p=productos-editar&id=<?= (int)$p['id'] ?>">Editar</a>
                 <?php if ((int)$p['activo'] === 1): ?>
                   <a class="btn btn-sm btn-outline-warning"
-                     href="index.php?p=productos-estado&id=<?= (int)$p['id'] ?>&a=desactivar"
+                     href="index.php?p=productos-estado&id=<?= (int)$p['id'] ?>&a=desactivar&csrf_token=<?= csrf_token() ?>"
                      onclick="return confirm('¿Desactivar este producto?');">Desactivar</a>
                 <?php else: ?>
                   <a class="btn btn-sm btn-outline-success"
-                     href="index.php?p=productos-estado&id=<?= (int)$p['id'] ?>&a=activar"
+                     href="index.php?p=productos-estado&id=<?= (int)$p['id'] ?>&a=activar&csrf_token=<?= csrf_token() ?>"
                      onclick="return confirm('¿Activar este producto?');">Activar</a>
                 <?php endif; ?>
               </td>

--- a/views/pages/productos/nuevo.php
+++ b/views/pages/productos/nuevo.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/csrf.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -12,6 +13,7 @@ if ($isAdmin) {
 ?>
 <div class="card shadow-sm">
   <form class="card-body" method="post" action="index.php?p=productos-guardar">
+    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
     <?php if ($isAdmin): ?>
       <div class="mb-3">
         <label class="form-label">Propietario</label>


### PR DESCRIPTION
## Summary
- Add CSRF helper with token generation and validation
- Embed CSRF tokens in clients, products, invoices and expenses forms and state links
- Verify CSRF tokens in all guardar and estado scripts

## Testing
- `php -l includes/csrf.php views/pages/clientes/actualizar.php views/pages/clientes/editar.php views/pages/clientes/estado.php views/pages/clientes/guardar.php views/pages/clientes/index.php views/pages/clientes/nuevo.php views/pages/facturas/estado.php views/pages/facturas/guardar.php views/pages/facturas/index.php views/pages/facturas/nuevo.php views/pages/gastos/estado.php views/pages/gastos/guardar.php views/pages/gastos/index.php views/pages/gastos/nuevo.php views/pages/productos/actualizar.php views/pages/productos/editar.php views/pages/productos/estado.php views/pages/productos/guardar.php views/pages/productos/index.php views/pages/productos/nuevo.php`

------
https://chatgpt.com/codex/tasks/task_e_689d839f0a308321ba6485f8efbaedf4