### PR TITLE
Harden session handling and logout caching

### DIFF
--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,6 +1,8 @@
 <?php
+require_once __DIR__ . '/session.php';
+
 function csrf_token(): string {
-  if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+  secure_session_start();
   if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
   }
@@ -8,7 +10,7 @@ function csrf_token(): string {
 }
 
 function csrf_check(): void {
-  if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+  secure_session_start();
   $token = $_POST['csrf_token'] ?? $_GET['csrf_token'] ?? '';
   if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
     exit('CSRF token inválido');

--- a/includes/session.php
+++ b/includes/session.php
@@ -1,0 +1,12 @@
+<?php
+function secure_session_start(): void {
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_set_cookie_params([
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'Lax'
+        ]);
+        session_start();
+    }
+}
+?>

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__ . '/../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/conexion.php';
 require_once __DIR__ . '/../includes/auth.php';

--- a/public/login.php
+++ b/public/login.php
@@ -1,6 +1,7 @@
 <?php
 // public/login.php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/conexion.php';
 

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,21 +1,28 @@
 <?php
 // public/logout.php
-if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
+require_once __DIR__ . '/../includes/session.php';
+secure_session_start();
 
 // Vaciar sesión
 $_SESSION = [];
 
 // Borrar cookie de sesión
-if (ini_get('session.use_cookies')) {
-  $p = session_get_cookie_params();
-  setcookie(session_name(), '', time() - 42000, $p['path'], $p['domain'], $p['secure'], $p['httponly']);
-}
+$p = session_get_cookie_params();
+setcookie(session_name(), '', [
+  'expires' => time() - 42000,
+  'path' => $p['path'],
+  'domain' => $p['domain'],
+  'secure' => $p['secure'],
+  'httponly' => $p['httponly'],
+  'samesite' => $p['samesite'] ?? 'Lax',
+]);
 
 // Destruir
 session_destroy();
 
-// Regenerar por seguridad
-session_start(); session_regenerate_id(true); session_write_close();
+// Cabeceras para evitar caché
+header('Cache-Control: no-store');
+header('Pragma: no-cache');
 
 // al final de public/logout.php
 $basePublic = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/\\');

--- a/views/pages/clientes/actualizar.php
+++ b/views/pages/clientes/actualizar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/pages/clientes/estado.php
+++ b/views/pages/clientes/estado.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/pages/clientes/guardar.php
+++ b/views/pages/clientes/guardar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/pages/config/guardar.php
+++ b/views/pages/config/guardar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 

--- a/views/pages/config/logo.php
+++ b/views/pages/config/logo.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 

--- a/views/pages/config/password.php
+++ b/views/pages/config/password.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 

--- a/views/pages/dashboard.php
+++ b/views/pages/dashboard.php
@@ -1,6 +1,7 @@
 <?php
 // views/pages/dashboard.php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../includes/config.php';
 require_once __DIR__ . '/../../includes/conexion.php';
 require_once __DIR__ . '/../../includes/auth.php';

--- a/views/pages/facturas/estado.php
+++ b/views/pages/facturas/estado.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/pages/gastos/adjuntar.php
+++ b/views/pages/gastos/adjuntar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/pages/gastos/estado.php
+++ b/views/pages/gastos/estado.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/csrf.php';

--- a/views/pages/gastos/guardar.php
+++ b/views/pages/gastos/guardar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/csrf.php';

--- a/views/pages/gastos/quitar_adjunto.php
+++ b/views/pages/gastos/quitar_adjunto.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 

--- a/views/pages/gastos/subir_adjunto.php
+++ b/views/pages/gastos/subir_adjunto.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 

--- a/views/pages/productos/actualizar.php
+++ b/views/pages/productos/actualizar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/pages/productos/estado.php
+++ b/views/pages/productos/estado.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/pages/productos/guardar.php
+++ b/views/pages/productos/guardar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';

--- a/views/partials/sidebar.php
+++ b/views/partials/sidebar.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../includes/session.php';
+secure_session_start();
 require_once __DIR__ . '/../../includes/conexion.php'; // para leer el logo desde BD
 
 // Activo en el menú


### PR DESCRIPTION
## Summary
- add helper to start sessions with secure cookie flags
- expire session cookie and disable caching on logout

## Testing
- `php -l includes/session.php includes/csrf.php public/index.php public/login.php public/logout.php views/pages/clientes/actualizar.php views/pages/clientes/estado.php views/pages/clientes/guardar.php views/pages/config/guardar.php views/pages/config/logo.php views/pages/config/password.php views/pages/dashboard.php views/pages/facturas/estado.php views/pages/gastos/adjuntar.php views/pages/gastos/estado.php views/pages/gastos/guardar.php views/pages/gastos/quitar_adjunto.php views/pages/gastos/subir_adjunto.php views/pages/productos/actualizar.php views/pages/productos/estado.php views/pages/productos/guardar.php views/partials/sidebar.php`

------
https://chatgpt.com/codex/tasks/task_e_689d855032c88321bffce74b38a6627c