### PR TITLE
Use usuario_rol session key in admin check

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,6 +1,6 @@
 <?php
 function is_admin(): bool {
-  $rol = strtolower((string)($_SESSION['rol'] ?? $_SESSION['role'] ?? ''));
+  $rol = strtolower((string)($_SESSION['usuario_rol'] ?? $_SESSION['rol'] ?? $_SESSION['role'] ?? ''));
   return in_array($rol, ['admin','administrador','super','superadmin','superusuario'])
          || !empty($_SESSION['modo_compacto']) || !empty($_SESSION['is_admin']);
 }


### PR DESCRIPTION
## Summary
- update `is_admin()` to read `usuario_rol` session key
- keep backward compatibility with previous `rol`/`role` keys

## Testing
- `php -l includes/auth.php`


------
https://chatgpt.com/codex/tasks/task_e_689d877900348321b260993c29244ae8