### PR TITLE
Move uploads directory outside public for security

### DIFF
--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,0 +1,4 @@
+# Disable script execution in uploads
+Options -ExecCGI
+RemoveHandler .php .phtml .php3 .php4 .php5 .php7 .pl .py .jsp .asp .sh .cgi
+php_flag engine off

--- a/views/pages/config/logo.php
+++ b/views/pages/config/logo.php
@@ -20,15 +20,17 @@ if (!$info || !isset($allowed[$info['mime']])) $err = 'Formato no permitido (usa
 if ($err) { exit($err); }
 
 $ext = $allowed[$info['mime']];
-$dir = __DIR__ . '/../../../public/uploads/logos';
+$baseDir = __DIR__ . '/../../../uploads';
+if (!is_dir($baseDir)) { @mkdir($baseDir, 0775, true); }
+$dir = $baseDir . '/logos';
 if (!is_dir($dir)) { @mkdir($dir, 0775, true); }
-$filename = 'u'.$uid.'_'.date('Ymd_His').'.'.$ext;
+$filename = bin2hex(random_bytes(16)) . '.' . $ext;
 $destAbs = $dir . '/' . $filename;
 if (!move_uploaded_file($_FILES['logo']['tmp_name'], $destAbs)) {
   exit('No se pudo mover el archivo subido.');
 }
 
-// Ruta relativa para servir desde /public
+// Ruta relativa para servir desde /uploads
 $relative = 'uploads/logos/'.$filename;
 
 // (Opcional) borra logo anterior si existe y está bajo /uploads/logos/
@@ -36,7 +38,7 @@ $old = $pdo->prepare("SELECT logo FROM usuarios WHERE id=?");
 $old->execute([$uid]);
 $prev = $old->fetchColumn();
 if ($prev && strpos($prev, 'uploads/logos/') === 0) {
-  @unlink(__DIR__ . '/../../../public/' . $prev);
+  @unlink(__DIR__ . '/../../../' . $prev);
 }
 
 $upd = $pdo->prepare("UPDATE usuarios SET logo=? WHERE id=?");

--- a/views/pages/gastos/guardar.php
+++ b/views/pages/gastos/guardar.php
@@ -90,17 +90,17 @@ try {
     }
     $ext = $allow[$mime];
 
-    // Carpeta: /public/uploads/gastos/u{uid}/YYYY/MM
-    $subdir = 'uploads/gastos/u' . $uid . '/' . date('Y') . '/' . date('m');
-    $absDir = realpath(__DIR__ . '/../../../public');
-    if ($absDir === false) { throw new RuntimeException('No existe carpeta /public.'); }
-    $destDir = $absDir . DIRECTORY_SEPARATOR . $subdir;
+    // Carpeta: /uploads/gastos/u{uid}/YYYY/MM
+    $baseDir = __DIR__ . '/../../../uploads';
+    if (!is_dir($baseDir)) { @mkdir($baseDir, 0775, true); }
+    $subdir = 'gastos/u' . $uid . '/' . date('Y') . '/' . date('m');
+    $destDir = $baseDir . DIRECTORY_SEPARATOR . $subdir;
     if (!is_dir($destDir)) { @mkdir($destDir, 0775, true); }
 
     // Nombre único
-    $filename = 'g'.$gid.'_'.date('Ymd_His').'.'.$ext;
+    $filename = bin2hex(random_bytes(16)) . '.' . $ext;
     $destAbs  = $destDir . DIRECTORY_SEPARATOR . $filename;
-    $destRel  = $subdir . '/' . $filename; // lo que guardamos en BD
+    $destRel  = 'uploads/' . $subdir . '/' . $filename; // lo que guardamos en BD
 
     if (!move_uploaded_file($_FILES['archivo']['tmp_name'], $destAbs)) {
       throw new RuntimeException('No se pudo mover el archivo subido.');

--- a/views/pages/gastos/subir_adjunto.php
+++ b/views/pages/gastos/subir_adjunto.php
@@ -42,18 +42,16 @@ try {
   $ext = $allow[$mime];
 
   // Directorio destino
-  $subdir = 'uploads/gastos/u' . $uid . '/' . date('Y') . '/' . date('m');
-  $absPublic = realpath(__DIR__ . '/../../../public');
-  if ($absPublic === false) {
-    throw new RuntimeException('No existe carpeta /public.');
-  }
-  $destDir = $absPublic . DIRECTORY_SEPARATOR . $subdir;
+  $baseDir = __DIR__ . '/../../../uploads';
+  if (!is_dir($baseDir)) { @mkdir($baseDir, 0775, true); }
+  $subdir = 'gastos/u' . $uid . '/' . date('Y') . '/' . date('m');
+  $destDir = $baseDir . DIRECTORY_SEPARATOR . $subdir;
   if (!is_dir($destDir)) { @mkdir($destDir, 0775, true); }
 
   // Nombre único
-  $filename = 'g'.$id.'_'.date('Ymd_His').'.'.$ext;
+  $filename = bin2hex(random_bytes(16)) . '.' . $ext;
   $destAbs  = $destDir . DIRECTORY_SEPARATOR . $filename;
-  $destRel  = $subdir . '/' . $filename;
+  $destRel  = 'uploads/' . $subdir . '/' . $filename;
 
   if (!move_uploaded_file($_FILES['archivo']['tmp_name'], $destAbs)) {
     throw new RuntimeException('No se pudo mover el archivo subido.');
@@ -65,7 +63,8 @@ try {
 
   // Borrar adjunto anterior (si existía)
   if (!empty($row['archivo'])) {
-    $oldAbs = $absPublic . DIRECTORY_SEPARATOR . str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $row['archivo']);
+    $oldPath = preg_replace('#^uploads/#', '', $row['archivo']);
+    $oldAbs = $baseDir . DIRECTORY_SEPARATOR . str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $oldPath);
     if (is_file($oldAbs)) { @unlink($oldAbs); }
   }
 


### PR DESCRIPTION
## Summary
- store uploaded logos and expense files in `../uploads` outside the public webroot
- generate cryptographically random filenames for uploads
- add `.htaccess` to disable script execution in uploads directory

## Testing
- `php -l views/pages/config/logo.php`
- `php -l views/pages/gastos/guardar.php`
- `php -l views/pages/gastos/subir_adjunto.php`


------
https://chatgpt.com/codex/tasks/task_e_689d88f9cd788321995e26c43e5eb314