### PR TITLE
security(session): cookie secure condicional + redirect en logout

### DIFF
--- a/includes/session.php
+++ b/includes/session.php
@@ -1,12 +1,14 @@
 <?php
 function secure_session_start(): void {
-    if (session_status() !== PHP_SESSION_ACTIVE) {
-        session_set_cookie_params([
-            'secure' => true,
-            'httponly' => true,
-            'samesite' => 'Lax'
-        ]);
-        session_start();
-    }
+  if (session_status() !== PHP_SESSION_ACTIVE) {
+    $isHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || (($_SERVER['SERVER_PORT'] ?? '') == 443);
+    session_set_cookie_params([
+      'secure'   => $isHttps,
+      'httponly' => true,
+      'samesite' => 'Lax',
+      'path'     => '/',
+    ]);
+    session_start();
+  }
 }
-?>
+


### PR DESCRIPTION
## Summary
- Harden session cookies with conditional `secure`, `httponly`, `samesite=Lax`, and root path parameters.
- Confirm login, index, and logout all initialize sessions through `secure_session_start` and logout redirects to login.

## Testing
- `php -l includes/session.php`
- `php -l public/login.php`
- `php -l public/index.php`
- `php -l public/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_689d94f1fdb483218cabaf8fc198ec65