### PR TITLE
feat(gastos): endpoint de descarga autenticada y enlaces seguros

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -173,6 +173,10 @@ case 'config-logo':         // Logo (multipart/form-data)
 	require __DIR__ . '/../views/pages/gastos/quitar_adjunto.php';
 	break;
 
+	case 'gastos-archivo':
+	require __DIR__ . '/../views/pages/gastos/archivo.php';
+	break;
+
 
   
   default:

--- a/views/pages/gastos/archivo.php
+++ b/views/pages/gastos/archivo.php
@@ -1,0 +1,41 @@
+<?php
+// views/pages/gastos/archivo.php
+require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/conexion.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+  http_response_code(401);
+  exit('No autorizado');
+}
+
+$uid = (int)$_SESSION['usuario_id'];
+$id  = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT) ?: 0;
+
+$stmt = $pdo->prepare("SELECT archivo FROM gastos WHERE id=? AND usuario_id=?");
+$stmt->execute([$id, $uid]);
+$rel = $stmt->fetchColumn();
+
+if (!$rel || strpos($rel, 'uploads/gastos/u' . $uid . '/') !== 0) {
+  http_response_code(404);
+  exit('No encontrado');
+}
+
+$base = realpath(dirname(__DIR__, 3) . '/uploads');
+$path = $base . DIRECTORY_SEPARATOR . str_replace(['uploads/', '\\', '..'], ['', DIRECTORY_SEPARATOR, ''], $rel);
+$real = realpath($path);
+
+if (!$real || strpos($real, $base) !== 0 || !is_file($real)) {
+  http_response_code(404);
+  exit('No encontrado');
+}
+
+$mime = function_exists('mime_content_type')
+  ? (mime_content_type($real) ?: 'application/octet-stream')
+  : 'application/octet-stream';
+
+header('Content-Type: ' . $mime);
+header('Content-Length: ' . filesize($real));
+header('Content-Disposition: inline; filename="' . basename($real) . '"');
+readfile($real);
+exit;
+

--- a/views/pages/gastos/index.php
+++ b/views/pages/gastos/index.php
@@ -159,7 +159,8 @@ function nf($n){ return number_format((float)$n, 2, ',', '.'); }
               <td class="text-end"><?= nf($r['total'] ?? 0) ?> €</td>
               <td class="text-center">
                 <?php if (!empty($r['archivo'])): ?>
-                  <a href="<?= htmlspecialchars($r['archivo']) ?>" target="_blank" title="Ver adjunto">📎 Ver</a>
+                  <!-- Enlace seguro vía controlador -->
+                  <a href="index.php?p=gastos-archivo&id=<?= (int)$r['id'] ?>" target="_blank" title="Ver adjunto">📎 Ver</a>
                 <?php else: ?>
                   —
                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- limit expense attachments to owners via authenticated download endpoint
- route attachment links through the new secure controller

## Testing
- `php -l views/pages/gastos/archivo.php`
- `php -l views/pages/gastos/index.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689d96b36ef48321994a28207d5cecb3