### PR TITLE
security(xss): helper h() y escape en vistas

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,2 @@
+<?php
+function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }

--- a/public/index.php
+++ b/public/index.php
@@ -4,6 +4,7 @@ secure_session_start();
 require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/conexion.php';
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/helpers.php';
 
 // ⬇️ usa tu login real (ruta relativa desde /public)
 if (!isset($_SESSION['usuario_id'])) {

--- a/public/login.php
+++ b/public/login.php
@@ -5,9 +5,8 @@ secure_session_start();
 require_once __DIR__ . '/../includes/config.php';
 require_once __DIR__ . '/../includes/conexion.php';
 require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/../includes/helpers.php';
 
-/* ------------------ helpers ------------------ */
-function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
 /* Si ya hay sesión, vete al dashboard */
 if (!empty($_SESSION['usuario_id'])) {
   header('Location: index.php?p=dashboard');

--- a/views/layout.php
+++ b/views/layout.php
@@ -1,12 +1,13 @@
 <?php
+require_once __DIR__ . '/../includes/helpers.php';
 if (!isset($pageTitle)) $pageTitle = 'Panel';
 $current = $_GET['p'] ?? 'dashboard'; // para resaltar activo
 ?>
 <!doctype html>
 <html lang="es">
 <head>
-  <?php require __DIR__ . '/partials/head.php'; ?>
-  <title><?= htmlspecialchars($pageTitle) ?> GL-APP</title>
+    <?php require __DIR__ . '/partials/head.php'; ?>
+    <title><?= h($pageTitle) ?> GL-APP</title>
 </head>
 <body>
 
@@ -43,7 +44,7 @@ $current = $_GET['p'] ?? 'dashboard'; // para resaltar activo
 
   <main class="flex-grow-1 p-3 p-lg-4">
     <div class="container-fluid">
-      <h1 class="h4 mb-3"><?= htmlspecialchars($pageTitle) ?></h1>
+        <h1 class="h4 mb-3"><?= h($pageTitle) ?></h1>
       <?= $content ?? '' ?>
     </div>
   </main>

--- a/views/pages/clientes/actualizar.php
+++ b/views/pages/clientes/actualizar.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 csrf_check();
 
@@ -57,5 +58,5 @@ try {
   exit;
 } catch (Throwable $e) {
   $pdo->rollBack();
-  echo 'Error al actualizar: ' . $e->getMessage();
+  echo 'Error al actualizar: ' . h($e->getMessage());
 }

--- a/views/pages/clientes/editar.php
+++ b/views/pages/clientes/editar.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin = is_admin();
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT) ?: 0;
@@ -31,7 +32,7 @@ if ($isAdmin) {
         <select class="form-select" name="owner_id">
           <?php foreach($users as $u): ?>
             <option value="<?= (int)$u['id'] ?>" <?= ((int)$u['id']===(int)$c['usuario_id']?'selected':'') ?>>
-              <?= (int)$u['id'] ?> · <?= htmlspecialchars($u['nom']) ?>
+              <?= (int)$u['id'] ?> · <?= h($u['nom']) ?>
             </option>
           <?php endforeach; ?>
         </select>
@@ -41,35 +42,35 @@ if ($isAdmin) {
     <div class="row g-3">
       <div class="col-md-6">
         <label class="form-label">Nombre</label>
-        <input type="text" name="nombre" class="form-control" value="<?= htmlspecialchars($c['nombre']) ?>" required>
+        <input type="text" name="nombre" class="form-control" value="<?= h($c['nombre']) ?>" required>
       </div>
       <div class="col-md-3">
         <label class="form-label">CIF/NIF</label>
-        <input type="text" name="cif" class="form-control" value="<?= htmlspecialchars($c['cif']) ?>" required>
+        <input type="text" name="cif" class="form-control" value="<?= h($c['cif']) ?>" required>
       </div>
       <div class="col-md-3">
         <label class="form-label">Teléfono</label>
-        <input type="text" name="telefono" class="form-control" value="<?= htmlspecialchars($c['telefono']) ?>">
+        <input type="text" name="telefono" class="form-control" value="<?= h($c['telefono']) ?>">
       </div>
       <div class="col-12">
         <label class="form-label">Email</label>
-        <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($c['email']) ?>">
+        <input type="email" name="email" class="form-control" value="<?= h($c['email']) ?>">
       </div>
       <div class="col-md-6">
         <label class="form-label">Dirección</label>
-        <input type="text" name="direccion" class="form-control" value="<?= htmlspecialchars($c['direccion']) ?>">
+        <input type="text" name="direccion" class="form-control" value="<?= h($c['direccion']) ?>">
       </div>
       <div class="col-md-2">
         <label class="form-label">CP</label>
-        <input type="text" name="cp" class="form-control" value="<?= htmlspecialchars($c['cp']) ?>">
+        <input type="text" name="cp" class="form-control" value="<?= h($c['cp']) ?>">
       </div>
       <div class="col-md-2">
         <label class="form-label">Localidad</label>
-        <input type="text" name="localidad" class="form-control" value="<?= htmlspecialchars($c['localidad']) ?>">
+        <input type="text" name="localidad" class="form-control" value="<?= h($c['localidad']) ?>">
       </div>
       <div class="col-md-2">
         <label class="form-label">Provincia</label>
-        <input type="text" name="provincia" class="form-control" value="<?= htmlspecialchars($c['provincia']) ?>">
+        <input type="text" name="provincia" class="form-control" value="<?= h($c['provincia']) ?>">
       </div>
 
       <div class="col-md-3">

--- a/views/pages/clientes/index.php
+++ b/views/pages/clientes/index.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -35,8 +36,8 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <form class="row g-2 mb-3" method="get" action="index.php">
       <input type="hidden" name="p" value="clientes-index">
       <div class="col-lg-6 col-sm-8">
-        <input class="form-control" type="search" name="q" placeholder="Buscar por nombre, CIF, email o teléfono"
-               value="<?= htmlspecialchars($q) ?>">
+          <input class="form-control" type="search" name="q" placeholder="Buscar por nombre, CIF, email o teléfono"
+                 value="<?= h($q) ?>">
       </div>
       <div class="col-lg-3 col-sm-4">
         <select class="form-select" name="estado">
@@ -70,10 +71,10 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <?php endif; ?>
           <?php foreach($rows as $c): ?>
             <tr>
-              <td><?= htmlspecialchars($c['nombre']) ?></td>
-              <td><?= htmlspecialchars($c['cif']) ?></td>
-              <td><?= htmlspecialchars($c['email']) ?></td>
-              <td><?= htmlspecialchars($c['telefono']) ?></td>
+                <td><?= h($c['nombre']) ?></td>
+                <td><?= h($c['cif']) ?></td>
+                <td><?= h($c['email']) ?></td>
+                <td><?= h($c['telefono']) ?></td>
               <td>
                 <?php if ((int)$c['activo'] === 1): ?>
                   <span class="badge bg-success">Activo</span>
@@ -82,7 +83,7 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <?php endif; ?>
               </td>
               <?php if ($isAdmin): ?>
-                <td><?= htmlspecialchars($c['propietario'] ?: "Usuario #{$c['usuario_id']}") ?></td>
+                  <td><?= h($c['propietario'] ?: "Usuario #{$c['usuario_id']}") ?></td>
               <?php endif; ?>
               <td class="text-end">
                 <a class="btn btn-sm btn-outline-secondary" href="index.php?p=clientes-editar&id=<?= (int)$c['id'] ?>">Editar</a>

--- a/views/pages/clientes/nuevo.php
+++ b/views/pages/clientes/nuevo.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin = is_admin();
 
@@ -20,7 +21,7 @@ if ($isAdmin) {
         <select class="form-select" name="owner_id">
           <?php foreach($users as $u): ?>
             <option value="<?= (int)$u['id'] ?>" <?= ((int)$u['id']===$ownerId?'selected':'') ?>>
-              <?= (int)$u['id'] ?> · <?= htmlspecialchars($u['nom']) ?>
+              <?= (int)$u['id'] ?> · <?= h($u['nom']) ?>
             </option>
           <?php endforeach; ?>
         </select>

--- a/views/pages/config/index.php
+++ b/views/pages/config/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $uid = (int)$_SESSION['usuario_id'];
 
 // Carga datos del usuario logueado
@@ -8,8 +9,6 @@ $stmt->execute([$uid]);
 $u = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$u) { die('Usuario no encontrado'); }
 
-// helper
-function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
 $fuentes = ['system-ui','Arial','Helvetica','Georgia','Times New Roman','Verdana','Tahoma','Courier New','Inter','Roboto'];
 ?>
 <div class="card shadow-sm">

--- a/views/pages/dashboard.php
+++ b/views/pages/dashboard.php
@@ -5,6 +5,7 @@ secure_session_start();
 require_once __DIR__ . '/../../includes/config.php';
 require_once __DIR__ . '/../../includes/conexion.php';
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 $sessionId = (int)($_SESSION['usuario_id'] ?? 0);
 $isAdmin   = is_admin();
@@ -139,8 +140,8 @@ if (isset($_GET['debug'])) {
       <input type="hidden" name="p" value="dashboard">
       <select class="form-select form-select-sm" name="owner_id" onchange="this.form.submit()">
         <?php foreach($users as $u): ?>
-          <option value="<?= (int)$u['id'] ?>" <?= ($ownerId===(int)$u['id']?'selected':'') ?>>
-            #<?= (int)$u['id'] ?> · <?= htmlspecialchars($u['nom']) ?>
+            <option value="<?= (int)$u['id'] ?>" <?= ($ownerId===(int)$u['id']?'selected':'') ?>>
+              #<?= (int)$u['id'] ?> · <?= h($u['nom']) ?>
           </option>
         <?php endforeach; ?>
       </select>
@@ -203,7 +204,7 @@ if (isset($_GET['debug'])) {
           $h = max(6, (int)round(100 * ($pt['value'] / $maxVal))); ?>
           <div class="mini-bar">
             <div class="bar" style="height: <?= $h ?>%;"></div>
-            <div class="lbl"><?= htmlspecialchars(ucfirst($pt['label'])) ?></div>
+            <div class="lbl"><?= h(ucfirst($pt['label'])) ?></div>
           </div>
         <?php endforeach; ?>
       </div>
@@ -229,13 +230,13 @@ if (isset($_GET['debug'])) {
             <?php endif; ?>
             <?php foreach($ultFact as $f): ?>
               <tr>
-                <td><?= htmlspecialchars($f['fecha']) ?></td>
-                <td><?= htmlspecialchars(($f['serie']?:'A').'-'.$f['numero']) ?></td>
-                <td><?= htmlspecialchars($f['cliente']) ?></td>
+                <td><?= h($f['fecha']) ?></td>
+                <td><?= h(($f['serie']?:'A').'-'.$f['numero']) ?></td>
+                <td><?= h($f['cliente']) ?></td>
                 <td class="text-end"><?= nf($f['total']) ?> €</td>
                 <td class="text-end">
                   <?php $cls = $f['estado']==='pagada' ? 'badge-pagada' : ($f['estado']==='emitida' ? 'badge-emitida' : 'badge-borrador'); ?>
-                  <span class="badge-soft <?= $cls ?>"><?= htmlspecialchars(ucfirst($f['estado'])) ?></span>
+                    <span class="badge-soft <?= $cls ?>"><?= h(ucfirst($f['estado'])) ?></span>
                 </td>
                 <td class="text-end">
                   <a class="btn btn-sm btn-outline-primary" href="index.php?p=facturas-generarpdf&id=<?= (int)$f['id'] ?>">Abrir</a>
@@ -271,8 +272,8 @@ if (isset($_GET['debug'])) {
             <?php endif; ?>
             <?php foreach($ultCli as $c): ?>
               <tr>
-                <td><?= htmlspecialchars($c['nombre']) ?></td>
-                <td><?= htmlspecialchars($c['fecha_creacion'] ?: '') ?></td>
+                <td><?= h($c['nombre']) ?></td>
+                <td><?= h($c['fecha_creacion'] ?: '') ?></td>
                 <td class="text-end"><a class="btn btn-sm btn-outline-secondary" href="index.php?p=clientes-editar&id=<?= (int)$c['id'] ?>">Abrir</a></td>
               </tr>
             <?php endforeach; ?>

--- a/views/pages/facturas/generar_pdf.php
+++ b/views/pages/facturas/generar_pdf.php
@@ -1,6 +1,7 @@
 <?php
 // views/pages/facturas/generar_pdf.php
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -58,8 +59,6 @@ $irpfTot     = round($base * $irpfPercent / 100, 2);
 $totalSrv    = round($base + $ivaTot - $irpfTot, 2);
 
 function nf($n){ return number_format((float)$n, 2, ',', '.'); }
-function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
-
 // Badge por estado
 $badgeClass = 'secondary';
 if ($f['estado']==='emitida') $badgeClass='primary';

--- a/views/pages/facturas/guardar.php
+++ b/views/pages/facturas/guardar.php
@@ -2,6 +2,7 @@
 // views/pages/facturas/guardar.php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 csrf_check();
 
@@ -102,12 +103,12 @@ for ($intento = 0; $intento < 2; $intento++) {
       continue; // reintentar una vez
     }
     http_response_code(500);
-    echo "Error al guardar la factura: " . htmlspecialchars($e->getMessage());
+    echo "Error al guardar la factura: " . h($e->getMessage());
     exit;
   } catch (Throwable $e) {
     $pdo->rollBack();
     http_response_code(500);
-    echo "Error al guardar la factura: " . htmlspecialchars($e->getMessage());
+    echo "Error al guardar la factura: " . h($e->getMessage());
     exit;
   }
 }

--- a/views/pages/facturas/index.php
+++ b/views/pages/facturas/index.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -41,7 +42,7 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <form class="row g-2 mb-3" method="get" action="index.php">
       <input type="hidden" name="p" value="facturas-index">
       <div class="col-lg-4 col-sm-6">
-        <input class="form-control" type="search" name="q" placeholder="Buscar por nº o cliente" value="<?= htmlspecialchars($q) ?>">
+          <input class="form-control" type="search" name="q" placeholder="Buscar por nº o cliente" value="<?= h($q) ?>">
       </div>
       <div class="col-lg-2 col-6">
         <select class="form-select" name="estado">
@@ -51,8 +52,8 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <option value="pagada"  <?= $estado==='pagada'?'selected':''; ?>>Pagada</option>
         </select>
       </div>
-      <div class="col-lg-2 col-6"><input class="form-control" type="date" name="fini" value="<?= htmlspecialchars($fini) ?>"></div>
-      <div class="col-lg-2 col-6"><input class="form-control" type="date" name="ffin" value="<?= htmlspecialchars($ffin) ?>"></div>
+        <div class="col-lg-2 col-6"><input class="form-control" type="date" name="fini" value="<?= h($fini) ?>"></div>
+        <div class="col-lg-2 col-6"><input class="form-control" type="date" name="ffin" value="<?= h($ffin) ?>"></div>
       <div class="col-lg-2 col-6 d-grid"><button class="btn btn-primary">Filtrar</button></div>
     </form>
 
@@ -74,9 +75,9 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <?php endif; ?>
           <?php foreach($rows as $f): ?>
             <tr>
-              <td><?= htmlspecialchars($f['fecha']) ?></td>
-              <td><?= htmlspecialchars(($f['serie'] ?: 'A') . '-' . $f['numero']) ?></td>
-              <td><?= htmlspecialchars($f['cliente']) ?></td>
+                <td><?= h($f['fecha']) ?></td>
+                <td><?= h(($f['serie'] ?: 'A') . '-' . $f['numero']) ?></td>
+                <td><?= h($f['cliente']) ?></td>
               <td class="text-end"><?= number_format((float)$f['base_imponible'], 2, ',', '.') ?> €</td>
               <td class="text-end"><?= number_format((float)$f['total'], 2, ',', '.') ?> €</td>
               <td>

--- a/views/pages/facturas/nuevo.php
+++ b/views/pages/facturas/nuevo.php
@@ -2,11 +2,11 @@
 // views/pages/facturas/nuevo.php
 require_once __DIR__ . '/../../../includes/auth.php'; // sesión + $pdo
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 $uid = (int)$_SESSION['usuario_id'];
 
 /* Helpers */
-function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
 function resolver_serie(?string $cfgSerie, string $fecha): string {
   $ts = strtotime($fecha ?: date('Y-m-d'));
   $yy = date('y', $ts);

--- a/views/pages/gastos/adjuntar.php
+++ b/views/pages/gastos/adjuntar.php
@@ -4,6 +4,7 @@ secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 $uid = (int)$_SESSION['usuario_id'];
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
@@ -16,9 +17,6 @@ if (!$gasto) {
   die('Gasto no encontrado o sin permisos');
 }
 
-if (!function_exists('ga_h')) {
-  function ga_h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
-}
 ?>
 <div class="d-flex justify-content-between align-items-center mb-3">
   <h5 class="m-0">Adjuntar archivo — Gasto #<?= (int)$gasto['id'] ?></h5>
@@ -28,24 +26,24 @@ if (!function_exists('ga_h')) {
 <div class="card shadow-sm">
   <div class="card-body">
     <div class="mb-3">
-      <div class="text-muted small">Fecha</div>
-      <div><strong><?= ga_h($gasto['fecha'] ?: '') ?></strong></div>
+        <div class="text-muted small">Fecha</div>
+        <div><strong><?= h($gasto['fecha'] ?: '') ?></strong></div>
     </div>
     <div class="mb-3">
-      <div class="text-muted small">Número / Categoría</div>
-      <div><strong><?= ga_h($gasto['numero'] ?: '—') ?></strong> · <?= ga_h($gasto['categoria'] ?: '—') ?></div>
+        <div class="text-muted small">Número / Categoría</div>
+        <div><strong><?= h($gasto['numero'] ?: '—') ?></strong> · <?= h($gasto['categoria'] ?: '—') ?></div>
     </div>
 
     <?php if (!empty($gasto['archivo'])): ?>
       <div class="mb-3">
         <div class="text-muted small mb-1">Adjunto actual</div>
-        <?php if (preg_match('~\.(jpe?g|png|webp|heic|heif)$~i', $gasto['archivo'])): ?>
-          <a href="<?= ga_h($gasto['archivo']) ?>" target="_blank">
-            <img src="<?= ga_h($gasto['archivo']) ?>" alt="Adjunto actual" style="max-width: 320px; height:auto; border:1px solid #e5e7eb; border-radius:8px;">
+          <?php if (preg_match('~\.(jpe?g|png|webp|heic|heif)$~i', $gasto['archivo'])): ?>
+            <a href="<?= h($gasto['archivo']) ?>" target="_blank">
+              <img src="<?= h($gasto['archivo']) ?>" alt="Adjunto actual" style="max-width: 320px; height:auto; border:1px solid #e5e7eb; border-radius:8px;">
           </a>
-        <?php else: ?>
-          <a href="<?= ga_h($gasto['archivo']) ?>" target="_blank" class="btn btn-outline-secondary btn-sm">Abrir PDF actual</a>
-        <?php endif; ?>
+          <?php else: ?>
+            <a href="<?= h($gasto['archivo']) ?>" target="_blank" class="btn btn-outline-secondary btn-sm">Abrir PDF actual</a>
+          <?php endif; ?>
         <div class="mt-2">
           <a href="index.php?p=gastos-quitar-adjunto&id=<?= (int)$gasto['id'] ?>" class="btn btn-sm btn-outline-danger"
              onclick="return confirm('¿Quitar el adjunto actual?');">Quitar adjunto</a>

--- a/views/pages/gastos/guardar.php
+++ b/views/pages/gastos/guardar.php
@@ -4,6 +4,7 @@ secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 csrf_check();
 
@@ -105,5 +106,5 @@ try {
 } catch (Throwable $e) {
   if ($pdo->inTransaction()) $pdo->rollBack();
   http_response_code(500);
-  echo "Error al guardar el gasto: " . htmlspecialchars($e->getMessage());
+  echo "Error al guardar el gasto: " . h($e->getMessage());
 }

--- a/views/pages/gastos/index.php
+++ b/views/pages/gastos/index.php
@@ -2,6 +2,7 @@
 // views/pages/gastos/index.php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 $uid = (int)$_SESSION['usuario_id'];
 
@@ -68,7 +69,7 @@ function nf($n){ return number_format((float)$n, 2, ',', '.'); }
   <input type="hidden" name="p" value="gastos-index">
   <div class="col-auto">
     <label class="form-label">Año</label>
-    <input type="number" name="y" class="form-control" value="<?= htmlspecialchars((string)$y) ?>" style="width:110px">
+    <input type="number" name="y" class="form-control" value="<?= h((string)$y) ?>" style="width:110px">
   </div>
   <div class="col-auto">
     <label class="form-label">Mes</label>
@@ -83,7 +84,7 @@ function nf($n){ return number_format((float)$n, 2, ',', '.'); }
     <select name="cat" class="form-select">
       <option value="">(todas)</option>
       <?php foreach($categorias as $c): ?>
-        <option value="<?= htmlspecialchars($c) ?>" <?= $c===$cat?'selected':'' ?>><?= htmlspecialchars($c) ?></option>
+        <option value="<?= h($c) ?>" <?= $c===$cat?'selected':'' ?>><?= h($c) ?></option>
       <?php endforeach; ?>
     </select>
   </div>
@@ -149,9 +150,9 @@ function nf($n){ return number_format((float)$n, 2, ',', '.'); }
 
           <?php foreach($rows as $r): ?>
             <tr>
-              <td><?= htmlspecialchars($r['fecha'] ?? '') ?></td>
-              <td><?= htmlspecialchars($r['numero'] ?? '') ?></td>
-              <td><?= htmlspecialchars($r['categoria'] ?? '') ?></td>
+              <td><?= h($r['fecha'] ?? '') ?></td>
+              <td><?= h($r['numero'] ?? '') ?></td>
+              <td><?= h($r['categoria'] ?? '') ?></td>
               <td class="text-end"><?= nf($r['base_imponible']) ?> €</td>
               <td class="text-end"><?= nf($r['tipo_iva']) ?></td>
               <td class="text-end"><?= nf($r['iva']) ?> €</td>
@@ -170,7 +171,7 @@ function nf($n){ return number_format((float)$n, 2, ',', '.'); }
                 <?php
                   $cls = $r['estado']==='pagado' ? 'b-pag' : ($r['estado']==='finalizado' ? 'b-fin' : 'b-borr');
                 ?>
-                <span class="badge-soft <?= $cls ?>"><?= htmlspecialchars(ucfirst($r['estado'])) ?></span>
+                <span class="badge-soft <?= $cls ?>"><?= h(ucfirst($r['estado'])) ?></span>
               </td>
               <td class="text-end">
                 <div class="btn-group btn-group-sm">

--- a/views/pages/gastos/nuevo.php
+++ b/views/pages/gastos/nuevo.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
-function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 // Sugerir categorías previas (texto libre)
 $uid = (int)$_SESSION['usuario_id'];

--- a/views/pages/gastos/quitar_adjunto.php
+++ b/views/pages/gastos/quitar_adjunto.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../../../includes/session.php';
 secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 $uid = (int)$_SESSION['usuario_id'];
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
@@ -34,5 +35,5 @@ try {
 
 } catch (Throwable $e) {
   http_response_code(400);
-  echo "Error al quitar adjunto: " . htmlspecialchars($e->getMessage());
+  echo "Error al quitar adjunto: " . h($e->getMessage());
 }

--- a/views/pages/gastos/subir_adjunto.php
+++ b/views/pages/gastos/subir_adjunto.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../../../includes/session.php';
 secure_session_start();
 require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 $uid = (int)$_SESSION['usuario_id'];
 $id  = isset($_POST['id']) ? (int)$_POST['id'] : 0;
@@ -73,5 +74,5 @@ try {
 
 } catch (Throwable $e) {
   http_response_code(400);
-  echo "Error al subir adjunto: " . htmlspecialchars($e->getMessage());
+  echo "Error al subir adjunto: " . h($e->getMessage());
 }

--- a/views/pages/productos/actualizar.php
+++ b/views/pages/productos/actualizar.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../../includes/config.php';
 require_once __DIR__ . '/../../../includes/conexion.php';
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 
 csrf_check();
 
@@ -55,5 +56,5 @@ try {
   exit;
 } catch (Throwable $e) {
   $pdo->rollBack();
-  echo 'Error al actualizar: ' . $e->getMessage();
+  echo 'Error al actualizar: ' . h($e->getMessage());
 }

--- a/views/pages/productos/editar.php
+++ b/views/pages/productos/editar.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT) ?: 0;
@@ -31,7 +32,7 @@ if ($isAdmin) {
         <select class="form-select" name="owner_id">
           <?php foreach($users as $u): ?>
             <option value="<?= (int)$u['id'] ?>" <?= ((int)$u['id']===(int)$p['usuario_id']?'selected':'') ?>>
-              <?= (int)$u['id'] ?> · <?= htmlspecialchars($u['nom']) ?>
+              <?= (int)$u['id'] ?> · <?= h($u['nom']) ?>
             </option>
           <?php endforeach; ?>
         </select>
@@ -41,15 +42,15 @@ if ($isAdmin) {
     <div class="row g-3">
       <div class="col-md-4">
         <label class="form-label">Referencia</label>
-        <input type="text" name="referencia" class="form-control" value="<?= htmlspecialchars($p['referencia'] ?? '') ?>">
+        <input type="text" name="referencia" class="form-control" value="<?= h($p['referencia'] ?? '') ?>">
       </div>
       <div class="col-md-8">
         <label class="form-label">Nombre</label>
-        <input type="text" name="nombre" class="form-control" value="<?= htmlspecialchars($p['nombre']) ?>" required>
+        <input type="text" name="nombre" class="form-control" value="<?= h($p['nombre']) ?>" required>
       </div>
       <div class="col-12">
         <label class="form-label">Descripción</label>
-        <textarea name="descripcion" class="form-control" rows="3"><?= htmlspecialchars($p['descripcion'] ?? '') ?></textarea>
+        <textarea name="descripcion" class="form-control" rows="3"><?= h($p['descripcion'] ?? '') ?></textarea>
       </div>
       <div class="col-md-3">
         <label class="form-label">Precio unitario (€)</label>

--- a/views/pages/productos/index.php
+++ b/views/pages/productos/index.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -35,8 +36,8 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <form class="row g-2 mb-3" method="get" action="index.php">
       <input type="hidden" name="p" value="productos-index">
       <div class="col-lg-6 col-sm-8">
-        <input class="form-control" type="search" name="q" placeholder="Buscar por nombre, referencia o descripción"
-               value="<?= htmlspecialchars($q) ?>">
+          <input class="form-control" type="search" name="q" placeholder="Buscar por nombre, referencia o descripción"
+                 value="<?= h($q) ?>">
       </div>
       <div class="col-lg-3 col-sm-4">
         <select class="form-select" name="estado">
@@ -70,11 +71,11 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <?php endif; ?>
           <?php foreach($rows as $p): ?>
             <tr>
-              <td><?= htmlspecialchars($p['referencia'] ?? '') ?></td>
+                <td><?= h($p['referencia'] ?? '') ?></td>
               <td>
-                <div class="fw-semibold"><?= htmlspecialchars($p['nombre']) ?></div>
-                <?php if (!empty($p['descripcion'])): ?>
-                  <div class="text-muted small"><?= htmlspecialchars($p['descripcion']) ?></div>
+                  <div class="fw-semibold"><?= h($p['nombre']) ?></div>
+                  <?php if (!empty($p['descripcion'])): ?>
+                    <div class="text-muted small"><?= h($p['descripcion']) ?></div>
                 <?php endif; ?>
               </td>
               <td><?= number_format((float)$p['precio_unitario'], 2, ',', '.') ?> €</td>
@@ -87,7 +88,7 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <?php endif; ?>
               </td>
               <?php if ($isAdmin): ?>
-                <td><?= htmlspecialchars($p['propietario'] ?: "Usuario #{$p['usuario_id']}") ?></td>
+                  <td><?= h($p['propietario'] ?: "Usuario #{$p['usuario_id']}") ?></td>
               <?php endif; ?>
               <td class="text-end">
                 <a class="btn btn-sm btn-outline-secondary" href="index.php?p=productos-editar&id=<?= (int)$p['id'] ?>">Editar</a>

--- a/views/pages/productos/nuevo.php
+++ b/views/pages/productos/nuevo.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../../includes/auth.php';
 require_once __DIR__ . '/../../../includes/csrf.php';
+require_once __DIR__ . '/../../../includes/helpers.php';
 $sessionId = (int)$_SESSION['usuario_id'];
 $isAdmin   = is_admin();
 
@@ -20,7 +21,7 @@ if ($isAdmin) {
         <select class="form-select" name="owner_id">
           <?php foreach($users as $u): ?>
             <option value="<?= (int)$u['id'] ?>" <?= ((int)$u['id']===$ownerId?'selected':'') ?>>
-              <?= (int)$u['id'] ?> · <?= htmlspecialchars($u['nom']) ?>
+              <?= (int)$u['id'] ?> · <?= h($u['nom']) ?>
             </option>
           <?php endforeach; ?>
         </select>

--- a/views/partials/sidebar.php
+++ b/views/partials/sidebar.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../../includes/session.php';
 secure_session_start();
 require_once __DIR__ . '/../../includes/conexion.php'; // para leer el logo desde BD
 require_once __DIR__ . '/../../includes/csrf.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 // Activo en el menú
 function li_active($key, $current){ return $current === $key ? ' active' : ''; }
@@ -54,7 +55,7 @@ function render_menu($current){
   <!-- Cabecera/Logo -->
   <div class="text-center mb-3">
     <?php if ($logoUrl): ?>
-      <img src="<?= htmlspecialchars($logoUrl) ?>" alt="Logo" style="max-width: 150px; height:auto; object-fit:contain;">
+        <img src="<?= h($logoUrl) ?>" alt="Logo" style="max-width: 150px; height:auto; object-fit:contain;">
     <?php else: ?>
       <div class="fw-bold">Factura-app V3</div>
     <?php endif; ?>
@@ -102,7 +103,7 @@ function render_menu($current){
 
     <hr class="my-2">
     <div class="d-grid px-2 pb-2">
-  <form method="post" action="<?= htmlspecialchars($logoutHref) ?>">
+    <form method="post" action="<?= h($logoutHref) ?>">
     <?php csrf_field(); ?>
     <button type="submit" class="btn btn-danger">⎋ Cerrar sesión</button>
   </form>


### PR DESCRIPTION
## Summary
- add global `h()` HTML-escaping helper
- require helper in layout, sidebar, login and page controllers
- escape dynamic text in listings and forms to avoid XSS

## Testing
- `php -l public/index.php`
- `php -l public/login.php`
- `php -l views/layout.php`
- `php -l views/pages/clientes/actualizar.php`
- `php -l views/pages/clientes/editar.php`
- `php -l views/pages/clientes/index.php`
- `php -l views/pages/clientes/nuevo.php`
- `php -l views/pages/config/index.php`
- `php -l views/pages/dashboard.php`
- `php -l views/pages/facturas/generar_pdf.php`
- `php -l views/pages/facturas/guardar.php`
- `php -l views/pages/facturas/index.php`
- `php -l views/pages/facturas/nuevo.php`
- `php -l views/pages/gastos/adjuntar.php`
- `php -l views/pages/gastos/guardar.php`
- `php -l views/pages/gastos/index.php`
- `php -l views/pages/gastos/nuevo.php`
- `php -l views/pages/gastos/quitar_adjunto.php`
- `php -l views/pages/gastos/subir_adjunto.php`
- `php -l views/pages/productos/actualizar.php`
- `php -l views/pages/productos/editar.php`
- `php -l views/pages/productos/index.php`
- `php -l views/pages/productos/nuevo.php`
- `php -l views/partials/sidebar.php`
- `php -l includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_689da25527108321b8046ac406982739