### PR TITLE
docs: expand project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ MIT – ver `LICENSE`.
 
 ## Contribuir
 Lee `CONTRIBUTING.md`. Para vulnerabilidades: `SECURITY.md`.
+
+## Documentación
+
+La carpeta [docs/](docs) incluye guías detalladas:
+
+- [README general](docs/README.md)
+- [Instalación](docs/INSTALL.md)
+- [Esquema de base de datos](docs/DATABASE.md)
+- [PDF](docs/PDF.md)
+- [Tema / Estilo](docs/THEME.md)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -23,21 +23,26 @@ $pdo = new PDO("mysql:host=$DB_HOST;dbname=$DB_NAME;charset=utf8mb4",$DB_USER,$D
 ]);
 ```
 
-## 5) mPDF (PDF)
+## 5) Directorios de escritura
+- Crea las carpetas `facturas/` y `uploads/` en la raíz del proyecto.
+- Asegura permisos de escritura para el servidor web.
+- Versiona `facturas/` solo con `.gitkeep`; los PDFs generados se ignoran.
+
+## 6) mPDF (PDF)
 ```bash
 composer require mpdf/mpdf
 ```
 
-## 6) Usuario admin
+## 7) Usuario admin
 Genera un hash:
 ```php
 <?php echo password_hash('admin123', PASSWORD_DEFAULT);
 ```
 Inserta en `usuarios` con ese hash (ver `docs/DATABASE.md`).
 
-## 7) Fondo y tema
+## 8) Fondo y tema
 - Pon tu imagen en `public/assets/img/app-bg.jpg`.
 - Asegúrate de cargar `assets/css/theme-min.css` en el layout.
 
-## 8) Acceso
+## 9) Acceso
 `/public/login.php` → Dashboard → Sidebar.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# Documentación del proyecto
+
+Guías y referencias para trabajar con **Factura-app V3**.
+
+## Contenido
+- [Instalación](INSTALL.md)
+- [Esquema de base de datos](DATABASE.md)
+- [Generación de PDF](PDF.md)
+- [Tema / Estilo](THEME.md)
+
+## Arquitectura rápida
+- `public/` – router principal (`index.php`), login/logout y recursos estáticos.
+- `includes/` – configuración, conexión PDO, sesión, autenticación, CSRF y helpers.
+- `views/` – layout, sidebar y páginas (clientes, productos, facturas, gastos, dashboard, config).
+- `uploads/` – adjuntos de gastos (fuera de `/public`, se sirve autenticado).
+- `facturas/` – PDFs generados por usuario (`carpeta{usuario_id}`).
+
+## Seguridad
+- Sesiones seguras con `session_regenerate_id`, cookies `httponly`, `secure`, `samesite=strict`.
+- Formularios críticos protegidos con tokens CSRF.
+- Consultas preparadas con filtrado por `usuario_id`.
+- Adjuntos y PDFs fuera de `/public` y acceso autenticado.
+
+## Flujo de facturación
+1. `facturas/nuevo.php` permite seleccionar productos y calcula totales.
+2. `facturas/guardar.php` guarda cabecera y líneas en transacción.
+3. `facturas/generar_pdf.php` genera el PDF y lo almacena en `facturas/carpeta{usuario_id}`.
+
+Para más detalles, consulta cada archivo correspondiente dentro de `views/pages/facturas/`.


### PR DESCRIPTION
## Summary
- add docs/README as index for project guides
- document writable directories in docs/INSTALL
- reference documentation set from root README

## Testing
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689da4a5fa2c83219c9676aaa655fd6e