### PR TITLE
Use environment variables for database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=127.0.0.1
+DB_PORT=3307
+DB_NAME=factura-app-v3
+DB_USER=root
+DB_PASS=

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,8 +1,19 @@
 <?php
-// Ajusta tu conexión (recuerda puerto 3307)
-define('DB_HOST','127.0.0.1');
-define('DB_PORT','3307');
-define('DB_NAME','factura-app-v3');
-define('DB_USER','root');
-define('DB_PASS','');
+// Load environment variables from .env if present
+$envFile = __DIR__ . '/../.env';
+if (file_exists($envFile)) {
+    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
+    foreach ($vars as $key => $value) {
+        if (getenv($key) === false) {
+            putenv("{$key}={$value}");
+        }
+    }
+}
+
+// Database configuration
+define('DB_HOST', getenv('DB_HOST'));
+define('DB_PORT', getenv('DB_PORT'));
+define('DB_NAME', getenv('DB_NAME'));
+define('DB_USER', getenv('DB_USER'));
+define('DB_PASS', getenv('DB_PASS'));
 ?>


### PR DESCRIPTION
## Summary
- load database credentials from environment or .env file
- add example `.env` file for local configuration

## Testing
- `php -l includes/config.php`
- `php -l includes/conexion.php`


------
https://chatgpt.com/codex/tasks/task_e_689dab373ae883218f05591c0d17d3f3