### PR TITLE
Remove closing PHP tags and ensure newline

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -4,4 +4,4 @@ function is_admin(): bool {
   return in_array($rol, ['admin','administrador','super','superadmin','superusuario'])
          || !empty($_SESSION['modo_compacto']) || !empty($_SESSION['is_admin']);
 }
-?>
+

--- a/includes/conexion.php
+++ b/includes/conexion.php
@@ -5,4 +5,4 @@ $options = [
   PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
 ];
 $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
-?>
+

--- a/includes/config.php
+++ b/includes/config.php
@@ -16,4 +16,4 @@ define('DB_PORT', getenv('DB_PORT'));
 define('DB_NAME', getenv('DB_NAME'));
 define('DB_USER', getenv('DB_USER'));
 define('DB_PASS', getenv('DB_PASS'));
-?>
+

--- a/public/index.php
+++ b/public/index.php
@@ -184,4 +184,4 @@ case 'config-logo':         // Logo (multipart/form-data)
     http_response_code(404);
     echo 'Página no encontrada';
 }
-?>
+


### PR DESCRIPTION
## Summary
- remove closing PHP tag from configuration and auth helpers
- ensure connection script ends without PHP closing tag
- drop terminal PHP closing tag in router index

## Testing
- `php -l includes/auth.php`
- `php -l includes/conexion.php`
- `php -l includes/config.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689dacb42094832193c0bf6053f08e12