### PR TITLE
Manejar fallo de conexión PDO

### DIFF
--- a/includes/conexion.php
+++ b/includes/conexion.php
@@ -4,5 +4,10 @@ $options = [
   PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
   PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
 ];
-$pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+try {
+    $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+} catch (PDOException $e) {
+    error_log('Database connection failed: ' . $e->getMessage());
+    exit('Error connecting to the database.');
+}
 


### PR DESCRIPTION
## Summary
- Maneja fallo en la conexión PDO atrapando la excepción y registrando el error
- Termina la ejecución cuando no se puede conectar a la base de datos

## Testing
- `php -l includes/conexion.php`


------
https://chatgpt.com/codex/tasks/task_e_689dadead0ac832185e47c3b57436821